### PR TITLE
[#]rename: X-User-Id -> X-Account-Id

### DIFF
--- a/src/main/java/soma/edupi/gateway/config/RoutingConfig.java
+++ b/src/main/java/soma/edupi/gateway/config/RoutingConfig.java
@@ -20,6 +20,11 @@ public class RoutingConfig {
     @Value("${server-url.user.default-path}")
     private String USER_PATH;
 
+//    @Value("${server-url.lms.url}")
+//    private String LMS_URL;
+//    @Value("${server-url.lms.default-path}")
+//    private String LMS_PATH;
+
     @Value("${server-url.visualize.url}")
     private String VISUALIZE_URL;
     @Value("${server-url.visualize.default-path}")
@@ -32,15 +37,20 @@ public class RoutingConfig {
             .route("root_route", r -> r.path("/")
                 .filters(f -> f.setStatus(200))
                 .uri("no://op")) // health check
+
             .route(predicate -> predicate.path(VISUALIZE_PATH)
 //                .filters(f -> f.filter(authorizationFilter.apply(config -> config.setRequiredRole("ROLE_USER"))))
-                .uri(VISUALIZE_URL)) // code_visualize
+                .uri(VISUALIZE_URL)) // edupi-visualize
+
+//            .route(predicate -> predicate.path(LMS_PATH)
+//                .filters(f -> f.filter(authorizationFilter.apply(config -> config.setRequiredRole("ROLE_USER"))))
+//                .uri(LMS_URL)) // edupi-lms
 
             .route(predicate -> predicate.path(USER_PATH)
-                .uri(USER_URL)) // edupi_user
+                .uri(USER_URL)) // edupi-user
 
             .route(predicate -> predicate.path(DB_PATH)
-                .uri(DB_URL)) // edupi_db
+                .uri(DB_URL)) // edupi-db
 
             .build();
     }

--- a/src/main/java/soma/edupi/gateway/filter/AuthenticationFilter.java
+++ b/src/main/java/soma/edupi/gateway/filter/AuthenticationFilter.java
@@ -46,7 +46,7 @@ public class AuthenticationFilter extends AbstractGatewayFilterFactory<Authentic
             Claims claims = jwtProvider.getClaimsJson(token);
 
             ServerHttpRequest modifiedRequest = exchange.getRequest().mutate()
-                .header("X-User-Id", claims.get("id", Integer.class).toString())
+                .header("X-Account-Id", claims.get("accountId", Long.class).toString())
                 .build();
 
             return chain.filter(exchange.mutate().request(modifiedRequest).build());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- 

## 📝 작업 내용

- X-User-Id -> X-Account-Id header 이름 변경

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- account라는 명칭을 통일하기 위해 수정합니다.
- lms가 주석처리 된 이유는 아직 서버가 안올라가서 그렇습니다~
